### PR TITLE
계단정복 랭킹 상세 페이지 관련 프로토콜 작성

### DIFF
--- a/subprojects/our-map-protocol/src/main/proto/GetHomeViewData.proto
+++ b/subprojects/our-map-protocol/src/main/proto/GetHomeViewData.proto
@@ -13,8 +13,8 @@ message GetHomeViewDataResult {
     message VillageRankingEntry {
         string village_id = 1;
         string village_name = 2;
-        int32 rank = 3;
-        string progress_percentage = 4;
+        int32 progress_rank = 3; // 계단정복률 순위.
+        string progress_percentage = 4; // 계단정복률.
     }
 
     // 채워진 비율이 많은 순으로 정렬되어 내려간다.

--- a/subprojects/our-map-protocol/src/main/proto/GetVillageStatistics.proto
+++ b/subprojects/our-map-protocol/src/main/proto/GetVillageStatistics.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+import "model.proto";
+
+option java_multiple_files = true;
+option java_package = "ourMap.protocol";
+option java_outer_classname = "GetVillageStatisticsProto";
+
+// 계단정복 랭킹 상세 페이지에서 표시할 각종 통계를 조회하는 API.
+
+message GetVillageStatisticsParams {
+    string village_id = 1;
+}
+
+message GetVillageStatisticsResult {
+    Village village = 1;
+
+    int32 progress_rank = 2; // 계단정복률 순위. (현재 n위)
+    string progress_percentage = 3; // 계단정복률
+
+    bool is_favorite_village = 4;
+
+    int32 building_accessibility_count = 5; // 건물 접근성 정보 수.
+    int32 total_building_count = 6; // 총 건물 수.
+    int32 place_accessibility_count = 7; // 장소 접근성 정보 수.
+    int32 total_place_count = 8; // 총 장소 수.
+
+    int32 registered_user_count = 9; // n명과 함께 정복 중!
+
+    string eup_myeon_dong_name = 10; // OO동 건물 정복왕
+    User most_registered_user_nickname = 11; // 정복왕 정보
+    int32 next_coloring_remaining_count = 12; // 다음 색칠까지 건물 n개 남았어요!
+}

--- a/subprojects/our-map-protocol/src/main/proto/ListVillageDropdownItems.proto
+++ b/subprojects/our-map-protocol/src/main/proto/ListVillageDropdownItems.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+import "model.proto";
+
+option java_multiple_files = true;
+option java_package = "ourMap.protocol";
+option java_outer_classname = "ListVillageDropdownItemsProto";
+
+// 계단정복 랭킹 페이지의 동네 드롭다운에 노출할 아이템을 조회하는 API.
+
+message ListVillageDropdownItemsParams {
+}
+
+message ListVillageDropdownItemsResult {
+    message VillageDropdownItem {
+        string village_id = 1;
+        string village_name = 2;
+    }
+    repeated VillageDropdownItem village_dropdown_items = 1;
+}

--- a/subprojects/our-map-protocol/src/main/proto/RegisterFavoriteVillage.proto
+++ b/subprojects/our-map-protocol/src/main/proto/RegisterFavoriteVillage.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+import "model.proto";
+
+option java_multiple_files = true;
+option java_package = "ourMap.protocol";
+option java_outer_classname = "RegisterFavoriteVillageProto";
+
+// 동네 즐겨찾기 등록 API.
+
+message RegisterFavoriteVillageParams {
+    string village_id = 1;
+}
+
+message RegisterFavoriteVillageResult {
+    Village village = 1;
+}

--- a/subprojects/our-map-protocol/src/main/proto/UnregisterFavoriteVillage.proto
+++ b/subprojects/our-map-protocol/src/main/proto/UnregisterFavoriteVillage.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+import "model.proto";
+
+option java_multiple_files = true;
+option java_package = "ourMap.protocol";
+option java_outer_classname = "UnregisterFavoriteVillageProto";
+
+// 동네 즐겨찾기 등록 해제 API.
+
+message UnregisterFavoriteVillageParams {
+    string village_id = 1;
+}
+
+message UnregisterFavoriteVillageResult {
+    Village village = 1;
+}

--- a/subprojects/our-map-protocol/src/main/proto/model.proto
+++ b/subprojects/our-map-protocol/src/main/proto/model.proto
@@ -9,6 +9,12 @@ message Location {
     double lat = 2;
 }
 
+message User {
+    string id = 1;
+    string nickname = 2;
+    string instagram_id = 3;
+}
+
 message Place {
     string id = 1;
     string name = 2; // 장소의 human-readable한 이름.
@@ -45,6 +51,12 @@ message BuildingAccessibility {
 
     string building_id = 5;
     StringValue registered_user_name = 6; // 익명이면 null.
+}
+
+message Village {
+    string id = 1;
+    string name = 2;
+    bool is_favorite_village = 3;
 }
 
 message SiGunGu {

--- a/subprojects/our-map-server/src/main/kotlin/route/GetHomeViewData.kt
+++ b/subprojects/our-map-server/src/main/kotlin/route/GetHomeViewData.kt
@@ -34,7 +34,7 @@ fun Route.getHomeViewData() {
                             GetHomeViewDataResult.VillageRankingEntry.newBuilder()
                                 .setVillageId(village.id)
                                 .setVillageName("${eupMyeonDong.siGunGu.name} ${eupMyeonDong.name}")
-                                .setRank(idx + 1)
+                                .setProgressRank(idx + 1)
                                 .setProgressPercentage(
                                     (village.registerProgress * BigDecimal(100)).toString()
                                         // 소수점 부분이 0으로 끝나는 경우 처리


### PR DESCRIPTION
- 새로운 프로토콜 추가
  - /listVillageDropdownItems API
    - 읍면동 목록으로 대체하지 하지 않은 이유는, 계단정복 랭킹에서의 `동네`가 반드시 읍면동 단위라는 보장은 없을 것 같았기 때문입니다.
  - /getVillageStatistics API
  - /registerFavoriteVillage API
  - /unregisterFavoriteVillageAPI
- 기존 프로토콜 수정
  - /getHomeViewData API - 변수명을 보다 통일성 있게 변경