### PR TITLE
이 정보가 도움이 돼요 관련 프로토콜

### DIFF
--- a/subprojects/our-map-protocol/src/main/proto/CancelBuildingAccessibilityUpvote.proto
+++ b/subprojects/our-map-protocol/src/main/proto/CancelBuildingAccessibilityUpvote.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "ourMap.protocol";
+option java_outer_classname = "CancelBuildingAccessibilityUpvoteProto";
+
+// 이 정보가 도음이 돼요를 취소하기 위한 API.
+
+message CancelBuildingAccessibilityUpvoteParams {
+    string building_id = 1;
+}
+
+message CancelBuildingAccessibilityUpvoteResult {
+}

--- a/subprojects/our-map-protocol/src/main/proto/GiveBuildingAccessibilityUpvote.proto
+++ b/subprojects/our-map-protocol/src/main/proto/GiveBuildingAccessibilityUpvote.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "ourMap.protocol";
+option java_outer_classname = "GiveBuildingAccessibilityUpvoteProto";
+
+// 이 정보가 도음이 돼요를 주기 위한 API.
+
+message GiveBuildingAccessibilityUpvoteParams {
+    string building_id = 1;
+}
+
+message GiveBuildingAccessibilityUpvoteResult {
+}

--- a/subprojects/our-map-protocol/src/main/proto/model.proto
+++ b/subprojects/our-map-protocol/src/main/proto/model.proto
@@ -51,6 +51,9 @@ message BuildingAccessibility {
 
     string building_id = 5;
     StringValue registered_user_name = 6; // 익명이면 null.
+
+    bool is_upvoted = 7; // 도움이 돼요를 표시했는지 여부.
+    bool total_upvote_count = 8; // 도움이 돼요를 받은 총 횟수. 이 숫자에 따라 버튼 텍스트에 '도움이 돼요'나 '정확한 정보에요'를 사용한다.
 }
 
 message Village {

--- a/subprojects/our-map/src/test/kotlin/domain/village/UserFavoriteVillageServiceTest.kt
+++ b/subprojects/our-map/src/test/kotlin/domain/village/UserFavoriteVillageServiceTest.kt
@@ -1,10 +1,12 @@
 package domain.village
 
+import application.village.VillageApplicationService
 import application.village.villageApplicationModule
 import domain.DomainTestBase
 import domain.village.repository.VillageRepository
 import domain.village.service.UserFavoriteVillageService
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 import org.koin.test.inject
 
@@ -13,6 +15,12 @@ class UserFavoriteVillageServiceTest : DomainTestBase() {
 
     private val villageRepository by inject<VillageRepository>()
     private val userFavoriteVillageService by inject<UserFavoriteVillageService>()
+    private val villageApplicationService by inject<VillageApplicationService>()
+
+    @Before
+    fun setUp() {
+        villageApplicationService.upsertAll()
+    }
 
     @Test
     fun `정상적인 경우`() = transactionManager.doAndRollback {


### PR DESCRIPTION
- `/giveBuildingAccessibilityUpvote`와 /cancelBuildingAccessibilityUpvote`를 구현합니다.
- `BuildingAccessibility`에 이미 `도움이 돼요`를 표시했는지 여부를 내려줍니다.
- 버튼 텍스트에 `도움이 돼요`와 `정확한 정보에요` 중 어떤 것을 표시할지 판단하기 위해, 해당 건물 정보가 받은 총 upvote 개수를 내려줍니다.