### PR TITLE
에러 핸들링 고도화 관련 프로토콜 추가

### DIFF
--- a/subprojects/our-map-server/src/main/proto/model.proto
+++ b/subprojects/our-map-server/src/main/proto/model.proto
@@ -4,6 +4,10 @@ import "common.proto";
 
 option java_package = "ourMap.protocol";
 
+message OurMapError {
+    string message = 1;
+}
+
 message Location {
     double lng = 1;
     double lat = 2;


### PR DESCRIPTION
* 에러가 발생했을 때 내려줄 response body를 내려줍니다. 일단 다른 필드는 필요 없을 것 같아서 유저에게 보여줄 에러 메세지만 내려줍니다.
* 기존에는 모든 에러의 http status가 500으로 내려가고 있었는데, 이제부터는 아래와 같이 http status가 내려갑니다.
  * 유저가 잘못된 요청을 한 경우(e.g. params가 잘못됨) - 400
  * access token이 잘못된 경우 - 401
  * 그 외의 예상하지 못한 서버 에러 - 500